### PR TITLE
Linux Tests on 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.0.0"
 
     steps:
       - checkout

--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-swift-4.2-CONVERGENCE
+4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-os:
-  - osx
-osx_image: xcode10
+-os:
+  - linux
 env:
 language: generic
+dist: trusty
 install:
   - if [ $TRAVIS_OS_NAME = linux ]; then
       eval "$(curl -sL https://swiftenv.fuller.li/install.sh)";

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swift:412
+FROM norionomura/swift:42
 
 WORKDIR /package
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-ios:
 	set -o pipefail && \
 	xcodebuild test \
 		-scheme NonEmpty-Package \
-		-destination platform="iOS Simulator,name=iPhone 8,OS=11.3" \
+		-destination platform="iOS Simulator,name=iPhone XR,OS=12.0" \
 		| xcpretty
 
 test-swift:

--- a/Sources/NonEmpty/NonEmpty+RandomAccessCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+RandomAccessCollection.swift
@@ -1,3 +1,2 @@
-#if os(Linux)
-extension NonEmpty: RandomAccessCollection where C: RandomAccessCollection {}
-#endif
+// https://bugs.swift.org/browse/SR-8985
+//extension NonEmpty: RandomAccessCollection where C: RandomAccessCollection {}

--- a/Sources/NonEmpty/NonEmpty+RandomAccessCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+RandomAccessCollection.swift
@@ -1,1 +1,3 @@
+#if os(Linux)
 extension NonEmpty: RandomAccessCollection where C: RandomAccessCollection {}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.11.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest


### PR DESCRIPTION
I think 4.2 on Linux is broken :( The stuff we're doing is too fancy. Won't be able to deploy with the latest prelude till it's fixed.

```
swift: /home/buildnode/jenkins/workspace/oss-swift-4.2-package-linux-ubuntu-16_04/swift/lib/AST/GenericSignature.cpp:487: auto swift::GenericSignature::getSubstitutionMap(SubstitutionList)::(anonymous class)::operator()(swift::Type, ArrayRef<swift::Requirement>) const: Assertion `reqts[i].getSecondType()->getAnyNominal() == conformances[i].getRequirement()' failed.
#0 0x0000000004108b64 PrintStackTraceSignalHandler(void*) (/usr/bin/swift+0x4108b64)
#1 0x00000000041069f2 llvm::sys::RunSignalHandlers() (/usr/bin/swift+0x41069f2)
#2 0x0000000004108d12 SignalHandler(int) (/usr/bin/swift+0x4108d12)
#3 0x00007f59ce340390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
#4 0x00007f59cca7f428 gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x35428)
#5 0x00007f59cca8102a abort (/lib/x86_64-linux-gnu/libc.so.6+0x3702a)
#6 0x00007f59cca77bd7 (/lib/x86_64-linux-gnu/libc.so.6+0x2dbd7)
#7 0x00007f59cca77c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
#8 0x0000000001781308 bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const::$_5>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/usr/bin/swift+0x1781308)
#9 0x000000000177d6fa swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/usr/bin/swift+0x177d6fa)
#10 0x000000000177f1ef swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const (/usr/bin/swift+0x177f1ef)
#11 0x000000000157820e swift::ModuleFile::getTypeChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) (/usr/bin/swift+0x157820e)
#12 0x0000000001588a31 swift::ModuleFile::finishNormalConformance(swift::NormalProtocolConformance*, unsigned long) (/usr/bin/swift+0x1588a31)
#13 0x00000000017ed5f5 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/usr/bin/swift+0x17ed5f5)
#14 0x00000000017fc790 swift::LookUpConformanceInSubstitutionMap::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/usr/bin/swift+0x17fc790)
#15 0x0000000000cef889 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::LookUpConformanceInSubstitutionMap>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/usr/bin/swift+0xcef889)
#16 0x00000000017fcf7d getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/usr/bin/swift+0x17fcf7d)
#17 0x0000000001802dc8 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_19>(long, swift::TypeBase*) (/usr/bin/swift+0x1802dc8)
#18 0x00000000017feeb3 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/usr/bin/swift+0x17feeb3)
#19 0x00000000017fd6e1 substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) (/usr/bin/swift+0x17fd6e1)
#20 0x00000000017fc5e8 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/usr/bin/swift+0x17fc5e8)
#21 0x0000000001201082 (anonymous namespace)::SILTypeSubstituter::visitType(swift::CanType) (/usr/bin/swift+0x1201082)
#22 0x0000000001200c16 swift::CanTypeVisitor<(anonymous namespace)::SILTypeSubstituter, swift::CanType>::visit(swift::CanType) (/usr/bin/swift+0x1200c16)
#23 0x0000000001200cdb swift::CanTypeVisitor<(anonymous namespace)::SILTypeSubstituter, swift::CanType>::visit(swift::CanType) (/usr/bin/swift+0x1200cdb)
#24 0x00000000011fbb42 (anonymous namespace)::SILTypeSubstituter::substSILFunctionType(swift::CanTypeWrapper<swift::SILFunctionType>) (/usr/bin/swift+0x11fbb42)
#25 0x00000000011fb9dd swift::SILFunctionType::substGenericArgs(swift::SILModule&, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) (/usr/bin/swift+0x11fb9dd)
#26 0x00000000011fb946 swift::SILFunctionType::substGenericArgs(swift::SILModule&, swift::SubstitutionMap const&) (/usr/bin/swift+0x11fb946)
#27 0x00000000011fb883 swift::SILFunctionType::substGenericArgs(swift::SILModule&, llvm::ArrayRef<swift::Substitution>) (/usr/bin/swift+0x11fb883)
#28 0x0000000001257bb4 swift::SILType::substGenericArgs(swift::SILModule&, llvm::ArrayRef<swift::Substitution>) const (/usr/bin/swift+0x1257bb4)
#29 0x00000000012151a5 swift::ApplyInst::create(swift::SILDebugLocation, swift::SILValue, llvm::ArrayRef<swift::Substitution>, llvm::ArrayRef<swift::SILValue>, bool, llvm::Optional<swift::SILModuleConventions>, swift::SILFunction&, swift::SILOpenedArchetypesState&, swift::GenericSpecializationInformation const*) (/usr/bin/swift+0x12151a5)
#30 0x0000000000622a93 swift::SILBuilder::createApply(swift::SILLocation, swift::SILValue, llvm::ArrayRef<swift::Substitution>, llvm::ArrayRef<swift::SILValue>, bool, swift::GenericSpecializationInformation const*) (/usr/bin/swift+0x622a93)
#31 0x00000000015997b2 swift::SILDeserializer::readSILInstruction(swift::SILFunction*, swift::SILBasicBlock*, swift::SILBuilder&, unsigned int, llvm::SmallVectorImpl<unsigned long>&) (/usr/bin/swift+0x15997b2)
#32 0x0000000001595e7f swift::SILDeserializer::readSILFunctionChecked(llvm::PointerEmbeddedInt<unsigned int, 31>, swift::SILFunction*, llvm::StringRef, bool, bool) (/usr/bin/swift+0x1595e7f)
#33 0x00000000015aae1a swift::SILDeserializer::getAllSILFunctions() (/usr/bin/swift+0x15aae1a)
#34 0x000000000154a7f0 swift::SerializedSILLoader::getAllForModule(swift::Identifier, swift::FileUnit*) (/usr/bin/swift+0x154a7f0)
#35 0x00000000004de63f performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/usr/bin/swift+0x4de63f)
#36 0x00000000004da400 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/usr/bin/swift+0x4da400)
#37 0x000000000048a348 main (/usr/bin/swift+0x48a348)
#38 0x00007f59cca6a830 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x20830)
#39 0x0000000000488009 _start (/usr/bin/swift+0x488009)
Stack dump:
0.	Program arguments: /usr/bin/swift -frontend -merge-modules -emit-module /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Array~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+BidirectionalCollection~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Codable~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Collection~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Comparable~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Dictionary~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Equatable~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Hashable~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+MutableCollection~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+Random~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+RandomAccessCollection~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+RangeReplaceableCollection~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+SetAlgebra~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty+String~partial.swiftmodule /package/.build/x86_64-unknown-linux/debug/NonEmpty.build/NonEmpty~partial.swiftmodule -parse-as-library -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -target x86_64-unknown-linux -disable-objc-interop -sdk / -I /package/.build/x86_64-unknown-linux/debug -enable-testing -g -module-cache-path /package/.build/x86_64-unknown-linux/debug/ModuleCache -swift-version 4 -Onone -D SWIFT_PACKAGE -D DEBUG -emit-module-doc-path /package/.build/x86_64-unknown-linux/debug/NonEmpty.swiftdoc -module-name NonEmpty -o /package/.build/x86_64-unknown-linux/debug/NonEmpty.swiftmodule 
1.	While deserializing SIL function "$S8NonEmptyAAVyxGSkAASkRzrlSk5index_8offsetBy07limitedE05IndexQzSgAH_SiAHtFTW"
2.	While reading from 'NonEmpty'
3.	While finishing conformance for type 'NonEmpty<C>'
4.	While ... to 'RandomAccessCollection' in module 'Swift'
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: merge-module command failed due to signal 6 (use -v to see invocation)
error: terminated(1): /usr/bin/swift-build-tool -f /package/.build/debug.yaml test output:
    

make: *** [test-linux] Error 1
```