### PR TITLE
Fix compiler failure in Xcode 11

### DIFF
--- a/Sources/NonEmpty/NonEmpty+Collection.swift
+++ b/Sources/NonEmpty/NonEmpty+Collection.swift
@@ -1,4 +1,4 @@
-extension NonEmpty: Collection {
+extension NonEmpty {
   public enum Index: Comparable {
     case head
     case tail(C.Index)

--- a/Sources/NonEmpty/NonEmpty+MutableCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+MutableCollection.swift
@@ -28,7 +28,7 @@ extension NonEmpty: MutableCollection where C: MutableCollection {
 }
 
 extension NonEmpty where C: MutableCollection, C.Index == Int {
-  public subscript(position: Int) -> Element {
+  public subscript(position: C.Index) -> Element {
     get {
       return self[position == 0 ? .head : .tail(self.tail.startIndex + position - 1)]
     }

--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -1,4 +1,4 @@
-public struct NonEmpty<C: Collection> {
+public struct NonEmpty<C: Collection>: Collection {
   public typealias Element = C.Element
 
   public internal(set) var head: Element


### PR DESCRIPTION
Apparently by defining `NonEmpty` as conforming to `Collection` right away in its declaration (instead of in an extension), the compilation failure with a weird `DESERIALIZATION FAILURE` error, as mentioned on #15 seems to be fixed.

Even when performing a clean build, the target now successfully compiles. 🎉 (it didn't with the previous solution).

Not sure about the actual cause for this, but this definitely seems like a compiler bug (file ordering / dependency, perhaps? 🔮).

Fixes #15. 🎉