### PR TITLE
Remove conformance to Decodable/Encodable.

### DIFF
--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -19,7 +19,3 @@ extension NonEmpty: CustomStringConvertible {
 extension NonEmpty: Equatable where C: Equatable, C.Element: Equatable {}
 
 extension NonEmpty: Hashable where C: Hashable, C.Element: Hashable {}
-
-extension NonEmpty: Decodable where C: Decodable, C.Element: Decodable {}
-
-extension NonEmpty: Encodable where C: Encodable, C.Element: Encodable {}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -16,7 +16,6 @@ extension NonEmptyTests {
     ("testString", testString),
     ("testEquatable", testEquatable),
     ("testComparable", testComparable),
-    ("testCodable", testCodable),
     ("testNonEmptySetWithTrivialValue", testNonEmptySetWithTrivialValue),
     ("testMutableCollectionWithArraySlice", testMutableCollectionWithArraySlice)
   ]

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -180,13 +180,6 @@ final class NonEmptyTests: XCTestCase {
     XCTAssertEqual(NonEmptyArray(1), NonEmptyArray(1).sorted())
   }
 
-  func testCodable() throws {
-    let xs = NonEmptyArray(1, 2, 3)
-
-    XCTAssertEqual(xs, try JSONDecoder().decode(NonEmptyArray<Int>.self, from: JSONEncoder().encode(xs)))
-    XCTAssertEqual(xs, try JSONDecoder().decode(NonEmptyArray<Int>.self, from: Data("{\"head\":1,\"tail\":[2,3]}".utf8)))
-  }
-
   func testNonEmptySetWithTrivialValue() {
     let xs = NonEmptySet<TrivialHashable>(.init(value: 1), .init(value: 2))
     let ys = NonEmptySet<TrivialHashable>(.init(value: 2), .init(value: 1))


### PR DESCRIPTION
This is related to issue #21. 
Relying on the synthesized implementations for `Decodable` and `Encodable` restricts the ability of library users to implement custom decoding for this type. The impact this has downstream is significant:

Any of my types that have a `NonEmpty` property on them must now have a custom `Decodable` init, because `NonEmpty` does not support decoding from an array in a JSON response. If I were able to add this conformance in my own project, then I could write a single initializer that works with an array, which would allow me to rely on synthesized `Decodable` inits for my types that contain `NonEmpty` properties.

This PR removes both `Decodable` and `Encodable` with the intent of allowing downstream users to implement whatever support they need in their apps.