### PR TITLE
NonEmpty + AnyCollection initialization

### DIFF
--- a/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
+++ b/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
@@ -8,6 +8,21 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.init(rawValue: tail)!
   }
 
+  public init?(_ collection: AnyCollection<Collection.Element>) {
+      guard !collection.isEmpty else { return nil }
+      var result = Collection()
+      collection.forEach { result.insert($0) }
+      self.init(rawValue: result)!
+  }
+
+  public init?(_ array: [Collection.Element]) {
+    self.init(AnyCollection(array))
+  }
+
+  public init?(_ arraySlice: ArraySlice<Collection.Element>) {
+    self.init(AnyCollection(arraySlice))
+  }
+
   public func contains(_ member: Collection.Element) -> Bool {
     self.rawValue.contains(member)
   }

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -106,6 +106,13 @@ final class NonEmptyTests: XCTestCase {
     XCTAssertFalse(NonEmptySet(1, 2, 3).isDisjoint(with: [3, 4, 5]))
   }
 
+  func testSetAlgebraAnyCollectionInitialization() {
+    let array: [Int] = [1, 2, 3]
+    XCTAssertEqual(NonEmptySet(AnyCollection(array)), NonEmptySet(1, 2, 3))
+    XCTAssertEqual(NonEmptySet(array), NonEmptySet(1, 2, 3))
+    XCTAssertEqual(NonEmptySet(array[0..<2]), NonEmptySet(1, 2))
+  }
+
   func testDictionary() {
     let nonEmptyDict1 = NonEmpty(("1", "Blob"), ["1": "Blobbo"], uniquingKeysWith: { $1 })
     XCTAssertEqual(1, nonEmptyDict1.count)


### PR DESCRIPTION
Hello! Firstly I want to say thank you for the cool library, which I've been using in my projects!

I faced a small problem while working with a library. I use `NonEmptySet` quite widely and for my point of view it doesn't have one feature, which is implemented in the vanilla `Set`. Possibility to be initialized from an array.  Right now I have 2 options to initialize `NonEmptySet` with vanilla `Set` itself and with the "head, tail" approach. However, I'm quite frequently using functions like `map` in my code, which converts vanilla set into the array. And as a result, I cannot create `NonEmptySet` from the mapped `Set`.

I wasn't sure about testing requirements, so I've created another test function for testing newly added methods.