### PR TITLE
Implement range subscript

### DIFF
--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -26,7 +26,7 @@ public struct NonEmpty<Collection: Swift.Collection>: Swift.Collection {
 
   public subscript(position: Index) -> Element { self.rawValue[position] }
 
-  public subscript(bounds: Range<Collection.Index>) -> SubSequence { self.rawValue[bounds] }
+  public subscript(bounds: Range<Index>) -> SubSequence { self.rawValue[bounds] }
 
   public func index(after i: Index) -> Index {
     self.rawValue.index(after: i)

--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -26,6 +26,8 @@ public struct NonEmpty<Collection: Swift.Collection>: Swift.Collection {
 
   public subscript(position: Index) -> Element { self.rawValue[position] }
 
+  public subscript(bounds: Range<Collection.Index>) -> SubSequence { self.rawValue[bounds] }
+
   public func index(after i: Index) -> Index {
     self.rawValue.index(after: i)
   }

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -35,6 +35,11 @@ final class NonEmptyTests: XCTestCase {
     XCTAssertEqual(43, xs[1])
   }
 
+  func testRangeSubscript() {
+    let xs = NonEmptyArray(1, 2, 3, 4)
+    XCTAssertEqual([2, 3], xs[1...2])
+  }
+
   func testRangeReplaceableCollection() {
     var xs = NonEmptyArray(1, 2, 3)
     xs.append(4)


### PR DESCRIPTION
Without implementing the range subscript, the following test
```swift
let xs = NonEmptyArray(1, 2, 3, 4)
let _ = xs[1...2]
```
resulted in a
```
EXC_BAD_ACCESS (code=2, address=0x7ffeef3ffff8)
```
Not sure if this is a Swift bug akin to https://forums.swift.org/t/i-think-i-found-another-misapplied-implementation/10276, but providing the implementation fixes the behavior.