### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import Foundation
 import PackageDescription
 
 let package = Package(
-  name: "NonEmpty",
+  name: "swift-nonempty",
   products: [
     .library(name: "NonEmpty", targets: ["NonEmpty"]),
   ],


### PR DESCRIPTION
This PR fixes import for swift-tools-version 5.3

SwiftPM was unable to resolve package at [`https://github.com/pointfreeco/swift-nonempty`](https://github.com/pointfreeco/swift-nonempty)

Maybe it's an SPM bug, but it saw neither `"NonEmpty"` nor `"swift-nonempty"` package names (now the second one works).

Also as far as I know (from some TCA issue and basic logic 🙂) you try to follow Apple's package naming guidelines like `"swift-log"`, `"swift-algorithms"` or `"swift-composable-architecture"`, so `"swift-notempty"` should fit this style more.