### PR TITLE
fix: Fixed ambiguous operator issue with swift-validated.

### DIFF
--- a/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
@@ -31,6 +31,12 @@ extension NonEmpty where Collection: RangeReplaceableCollection {
   public static func += <S: Sequence>(lhs: inout NonEmpty, rhs: S) where Element == S.Element {
     lhs.append(contentsOf: rhs)
   }
+  
+  public static func + (lhs: NonEmpty, rhs: NonEmpty) -> NonEmpty {
+    var lhs = lhs
+    lhs += rhs
+    return lhs
+  }
 
   public static func + <S: Sequence>(lhs: NonEmpty, rhs: S) -> NonEmpty where Element == S.Element {
     var lhs = lhs


### PR DESCRIPTION
This should fix https://github.com/pointfreeco/swift-nonempty/issues/36 by adding a more specific implementation in case both sides are NonEmpty.