### PR TITLE
Use SingleValueEncoding/DecodingContainer

### DIFF
--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -86,13 +86,24 @@ extension NonEmpty: Comparable where Collection: Comparable {
 
 extension NonEmpty: Encodable where Collection: Encodable {
   public func encode(to encoder: Encoder) throws {
-    try self.rawValue.encode(to: encoder)
+    do {
+      var container = encoder.singleValueContainer()
+      try container.encode(self.rawValue)
+    } catch {
+      try self.rawValue.encode(to: encoder)
+    }
   }
 }
 
 extension NonEmpty: Decodable where Collection: Decodable {
   public init(from decoder: Decoder) throws {
-    let collection = try Collection(from: decoder)
+    let collection: Collection
+    do {
+      collection = try decoder.singleValueContainer().decode(Collection.self)
+    } catch {
+      collection = try Collection(from: decoder)
+    }
+
     guard !collection.isEmpty else {
       throw DecodingError.dataCorrupted(
         .init(codingPath: decoder.codingPath, debugDescription: "Non-empty collection expected")

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -198,7 +198,7 @@ final class NonEmptyTests: XCTestCase {
       data, try JSONDecoder().decode(NonEmpty<Data>.self, from: JSONEncoder().encode(data)))
     XCTAssertEqual(
       data, try JSONDecoder().decode(NonEmpty<Data>.self, from: Data(#""SGVsbG8=""#.utf8)))
-    XCTAssertThrowsError(try JSONDecoder().decode(NonEmpty<Data>.self, from: Data(#""""#.utf8)))
+    XCTAssertThrowsError(try JSONDecoder().decode(NonEmpty<Data>.self, from: Data("\"\"".utf8)))
   }
 
   func testNonEmptySetWithTrivialValue() {

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -192,6 +192,13 @@ final class NonEmptyTests: XCTestCase {
     )
     XCTAssertThrowsError(
       try JSONDecoder().decode(NonEmpty<[String: Int]>.self, from: Data("{}".utf8)))
+
+    let data = NonEmpty(rawValue: Data("Hello".utf8))
+    XCTAssertEqual(
+      data, try JSONDecoder().decode(NonEmpty<Data>.self, from: JSONEncoder().encode(data)))
+    XCTAssertEqual(
+      data, try JSONDecoder().decode(NonEmpty<Data>.self, from: Data(#""SGVsbG8=""#.utf8)))
+    XCTAssertThrowsError(try JSONDecoder().decode(NonEmpty<Data>.self, from: Data(#""""#.utf8)))
   }
 
   func testNonEmptySetWithTrivialValue() {


### PR DESCRIPTION
Allow encoding/decoding Base64 data by using `SingleValueEncodingContainer` and `SingleValueDecodingContainer`.

See also:
https://github.com/pointfreeco/swift-tagged/pull/24

https://forums.swift.org/t/propery-wrapper-decoding-difference-between-singlevaluecontainer-and-init-from-decoder/51918