### PR TITLE
Conform to `ExpressibleByArrayLiteral` and `ExpressibleByDictionaryLiteral`

### DIFF
--- a/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
@@ -1,0 +1,14 @@
+extension NonEmpty: ExpressibleByArrayLiteral where Collection: _InitializableFromArray {
+  public init(arrayLiteral elements: Element...) {
+    assert(!elements.isEmpty, "Cannot initialize a NonEmpty array from an empty literal!")
+    self.init(rawValue: Collection(elements))!
+  }
+}
+
+public protocol _InitializableFromArray {
+  associatedtype Element
+
+  init(_ array: [Element])
+}
+
+extension Array: _InitializableFromArray {}

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
@@ -1,6 +1,6 @@
 extension NonEmpty: ExpressibleByArrayLiteral where Collection: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
-    assert(!elements.isEmpty, "Cannot initialize a NonEmpty array from an empty literal!")
+    precondition(!elements.isEmpty, "Can't construct \(Self.self) from empty array literal")
     let f = unsafeBitCast(
       Collection.init(arrayLiteral:),
       to: (([Element]) -> Collection).self

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
@@ -1,14 +1,10 @@
-extension NonEmpty: ExpressibleByArrayLiteral where Collection: _InitializableFromArray {
+extension NonEmpty: ExpressibleByArrayLiteral where Collection: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     assert(!elements.isEmpty, "Cannot initialize a NonEmpty array from an empty literal!")
-    self.init(rawValue: Collection(elements))!
+    let f = unsafeBitCast(
+      Collection.init(arrayLiteral:),
+      to: (([Element]) -> Collection).self
+    )
+    self.init(rawValue: f(elements))!
   }
 }
-
-public protocol _InitializableFromArray {
-  associatedtype Element
-
-  init(_ array: [Element])
-}
-
-extension Array: _InitializableFromArray {}

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
@@ -1,15 +1,10 @@
-extension NonEmpty: ExpressibleByDictionaryLiteral where Collection: _InitializableFromKeyValuePairs {
+extension NonEmpty: ExpressibleByDictionaryLiteral where Collection: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (Collection.Key, Collection.Value)...) {
     assert(!elements.isEmpty, "Cannot initialize a NonEmpty dictionary from an empty literal!")
-    self.init(rawValue: Collection(uniqueKeysWithValues: elements))!
+    let f = unsafeBitCast(
+      Collection.init(dictionaryLiteral:),
+      to: (([(Collection.Key, Collection.Value)]) -> Collection).self
+    )
+    self.init(rawValue: f(elements))!
   }
 }
-
-public protocol _InitializableFromKeyValuePairs {
-  associatedtype Key
-  associatedtype Value
-
-  init(uniqueKeysWithValues: [(Key, Value)])
-}
-
-extension Dictionary: _InitializableFromKeyValuePairs {}

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
@@ -1,0 +1,15 @@
+extension NonEmpty: ExpressibleByDictionaryLiteral where Collection: _InitializableFromKeyValuePairs {
+  public init(dictionaryLiteral elements: (Collection.Key, Collection.Value)...) {
+    assert(!elements.isEmpty, "Cannot initialize a NonEmpty dictionary from an empty literal!")
+    self.init(rawValue: Collection(uniqueKeysWithValues: elements))!
+  }
+}
+
+public protocol _InitializableFromKeyValuePairs {
+  associatedtype Key
+  associatedtype Value
+
+  init(uniqueKeysWithValues: [(Key, Value)])
+}
+
+extension Dictionary: _InitializableFromKeyValuePairs {}

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
@@ -1,6 +1,6 @@
 extension NonEmpty: ExpressibleByDictionaryLiteral where Collection: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (Collection.Key, Collection.Value)...) {
-    assert(!elements.isEmpty, "Cannot initialize a NonEmpty dictionary from an empty literal!")
+    precondition(!elements.isEmpty, "Can't construct \(Self.self) from empty dictionary literal")
     let f = unsafeBitCast(
       Collection.init(dictionaryLiteral:),
       to: (([(Collection.Key, Collection.Value)]) -> Collection).self

--- a/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
+++ b/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
@@ -16,6 +16,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.contains(member)
   }
 
+  @_disfavoredOverload
   public func union(_ other: NonEmpty) -> NonEmpty {
     var copy = self
     copy.formUnion(other)
@@ -28,6 +29,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     return copy
   }
 
+  @_disfavoredOverload
   public func intersection(_ other: NonEmpty) -> Collection {
     self.rawValue.intersection(other.rawValue)
   }
@@ -36,6 +38,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.intersection(other)
   }
 
+  @_disfavoredOverload
   public func symmetricDifference(_ other: NonEmpty) -> Collection {
     self.rawValue.symmetricDifference(other.rawValue)
   }
@@ -56,6 +59,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.update(with: newMember)
   }
 
+  @_disfavoredOverload
   public mutating func formUnion(_ other: NonEmpty) {
     self.rawValue.formUnion(other.rawValue)
   }
@@ -64,6 +68,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.formUnion(other)
   }
 
+  @_disfavoredOverload
   public func subtracting(_ other: NonEmpty) -> Collection {
     self.rawValue.subtracting(other.rawValue)
   }
@@ -72,6 +77,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.subtracting(other)
   }
 
+  @_disfavoredOverload
   public func isDisjoint(with other: NonEmpty) -> Bool {
     self.rawValue.isDisjoint(with: other.rawValue)
   }
@@ -80,6 +86,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.isDisjoint(with: other)
   }
 
+  @_disfavoredOverload
   public func isSubset(of other: NonEmpty) -> Bool {
     self.rawValue.isSubset(of: other.rawValue)
   }
@@ -88,6 +95,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.isSubset(of: other)
   }
 
+  @_disfavoredOverload
   public func isSuperset(of other: NonEmpty) -> Bool {
     self.rawValue.isSuperset(of: other.rawValue)
   }
@@ -96,6 +104,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.isSuperset(of: other)
   }
 
+  @_disfavoredOverload
   public func isStrictSubset(of other: NonEmpty) -> Bool {
     self.rawValue.isStrictSubset(of: other.rawValue)
   }
@@ -104,6 +113,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.rawValue.isStrictSubset(of: other)
   }
 
+  @_disfavoredOverload
   public func isStrictSuperset(of other: NonEmpty) -> Bool {
     self.rawValue.isStrictSuperset(of: other.rawValue)
   }

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -129,6 +129,8 @@ final class NonEmptyTests: XCTestCase {
     let ys: NonEmpty<[Int]> = [1, 2, 3]
 
     XCTAssertEqual(xs, ys)
+    XCTAssertEqual(xs, [1, 2, 3])
+    XCTAssertNotEqual(xs, [2, 1, 3])
   }
 
   func testExpressibleByDictionaryLiteral() {
@@ -136,6 +138,8 @@ final class NonEmptyTests: XCTestCase {
     let ys: NonEmpty<[String: String]> = ["a": "test", "b": "demo"]
 
     XCTAssertEqual(xs, ys)
+    XCTAssertEqual(xs, ["b": "demo", "a": "test"])
+    XCTAssertEqual(xs.rawValue, ["b": "demo", "a": "test"])
   }
 
   func testDictionary() {

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -124,6 +124,20 @@ final class NonEmptyTests: XCTestCase {
     XCTAssertFalse(NonEmptySet(1, 2, 3).isDisjoint(with: [3, 4, 5]))
   }
 
+  func testExpressibleByArrayLiteral() {
+    let xs = NonEmpty<[Int]>(1, 2, 3)
+    let ys: NonEmpty<[Int]> = [1, 2, 3]
+
+    XCTAssertEqual(xs, ys)
+  }
+
+  func testExpressibleByDictionaryLiteral() {
+    let xs = NonEmpty<[String: String]>(("a", "test"), ["b": "demo"])
+    let ys: NonEmpty<[String: String]> = ["a": "test", "b": "demo"]
+
+    XCTAssertEqual(xs, ys)
+  }
+
   func testDictionary() {
     let nonEmptyDict1 = NonEmpty(("1", "Blob"), ["1": "Blobbo"], uniquingKeysWith: { $1 })
     XCTAssertEqual(1, nonEmptyDict1.count)


### PR DESCRIPTION
### Fixes #48 

This branch adds experimental support for the aforementioned protocols.