### PR TITLE
Enumerated NonEmpty

### DIFF
--- a/Sources/NonEmpty/NonEmpty+Enumerated.swift
+++ b/Sources/NonEmpty/NonEmpty+Enumerated.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+extension NonEmpty {
+  public func enumerated() -> Enumerated<Collection> {
+    Enumerated(self)
+  }
+}
+
+extension NonEmpty {
+  public struct Enumerated<Collection: Swift.Collection> {
+    private let rawValue: Collection
+    
+    init(_ nonEmpty: NonEmpty<Collection>) {
+      rawValue = nonEmpty.rawValue
+    }
+    
+    public var first: Iterator.Element {
+      var iterator = makeIterator()
+      return iterator.next()!
+    }
+    
+    public func map<T>(_ transform: (Iterator.Element) throws -> T) rethrows -> NonEmpty<[T]> {
+      NonEmpty<[T]>(rawValue: try makeIterator().map(transform))!
+    }
+    
+    public func flatMap<SegmentOfResult>(
+      _ transform: (Iterator.Element) throws -> NonEmpty<SegmentOfResult>
+    ) rethrows -> NonEmpty<[SegmentOfResult.Element]> where SegmentOfResult: Sequence {
+      NonEmpty<[SegmentOfResult.Element]>(rawValue: try makeIterator().flatMap(transform))!
+    }
+    
+    public func shuffled<T>(using generator: inout T) -> NonEmpty<[Iterator.Element]>
+    where T: RandomNumberGenerator {
+      NonEmpty<[Iterator.Element]>(rawValue: makeIterator().shuffled(using: &generator))!
+    }
+    
+    public func shuffled() -> NonEmpty<[Iterator.Element]> {
+      NonEmpty<[Iterator.Element]>(rawValue: makeIterator().shuffled())!
+    }
+  }
+}
+
+extension NonEmpty.Enumerated: Sequence {
+  public typealias Iterator = EnumeratedSequence<Collection>.Iterator
+  
+  public func makeIterator() -> Iterator {
+    rawValue.enumerated().makeIterator()
+  }
+}

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -240,6 +240,44 @@ final class NonEmptyTests: XCTestCase {
       XCTAssertEqual(.init("A", "C", "B"), xs)
     }
   #endif
+  
+  func testEnumerated() {
+    let actual = NonEmptyArray("1", "2", "3").enumerated()
+    let expected = [(offset: 0, element: "1", (offset: 1, element: "2"), (offset: 2, element: "3"))]
+    
+    XCTAssertTrue(
+      zip(actual, expected).allSatisfy {
+        $0.offset == $1.offset && $0.element == $1.element
+      }
+    )
+  }
+
+  func testEnumeratedMap() {
+    let xs = NonEmptyArray(1, 2, 3).enumerated()
+    
+    let nonEmptyArray: NonEmpty<[String]> = xs.map { String($0.element) }
+    let array: [String] = xs.map { String($0.element) }
+    
+    XCTAssertEqual(nonEmptyArray, NonEmpty("1", "2", "3"))
+    XCTAssertEqual(array, ["1", "2", "3"])
+  }
+  
+  func testEnumeratedFlatMap() {
+    let xs = NonEmptyArray(NonEmptyArray("1"), NonEmptyArray("2"), NonEmptyArray("3")).enumerated()
+    
+    let nonEmptyArray: NonEmpty<[String]> = xs.flatMap { $0.element }
+    let array: [String] = xs.flatMap { $0.element }
+    
+    XCTAssertEqual(nonEmptyArray, NonEmpty("1", "2", "3"))
+    XCTAssertEqual(array, ["1", "2", "3"])
+  }
+  
+  func testEnumeratedFirst() {
+    let xs = NonEmptyArray("Blob").enumerated()
+    
+    XCTAssertEqual(xs.first.offset, 0)
+    XCTAssertEqual(xs.first.element, "Blob")
+  }
 }
 
 struct TrivialHashable: Equatable, Comparable, Hashable {


### PR DESCRIPTION
# Problem Statement

`NonEmpty` provides a compile-time guarantee that a collection contains a value. This invariant is preserved even after collection is transformed with `map`/`flatMap`/`shuffled` functions, which is expected. One would expect that enumerating a `NonEmpty` collection would also preserve this invariant, but it's not the case:

```swift
let xs = NonEmptyArray(1, 2, 3)
let a = xs.map(String.init) // ✅ still NonEmpty<[String]>
let b = xs.enumerated.map { "\($0.offset) \($0.element)" } // ⚠️ back to vanilla Array<String>
```
In order to get an enumerated `NonEmpty` result one has to either introduce an outer index, which feels gross and error prone:
```swift
var offset = 0
let b = xs.enumerated.map { 
  "\(offset) \($0)"
   offset += 1
}

```
or temporarily leave the `NonEmpty` context and force their way back:
```swift
let temp = xs.enumerated.map {  "\($0.offset) \($0.element)" }
let b = NonEmpty(rawValue: temp)!
```
# Motivation

Semantically, there seems to be no apparent reason for the nonemptiness invariant to be lost during the enumeration. Enumeration is just a case of `map` transformation that embellishes original collection with indexes, and `map` already preserves nonemptiness. Hence, enumeration should too.

# Implementation 

Introduce a dedicated `Enumerated` type nested in `NonEmpty`, echoing Swift's `EnumeratedSequence`. Implement all functions that preserve nonemptiness invariant: `map`, `flatMap`, `shuffled`, `first`, etc. Conform `NonEmpty.Enumerated` to `Sequence` to match the functionality of `EnumeratedSequence` for backwards compatibility:

```swift
let xs = NonEmptyArray(1, 2, 3).enumerated() // type NonEmpty<[Int]>.Enumerated

let nonEmptyArray: NonEmpty<[String]> = xs.map { "\($0.offset) \($0.element)" } // new map overload
let array: [String] = xs.map { String($0.element) } // type inference for vanilla Array map still works
```

# NB

Similar points could be made for other derivative sequence types, such as `LazySequence`, `Zip2Sequence` and `ReversedCollection`. For example, Haskell preserves nonemptiness when [zipping](https://hackage.haskell.org/package/base-4.17.0.0/docs/Data-List-NonEmpty.html#g:9).