### PR TITLE
Inlining functions

### DIFF
--- a/Sources/NonEmpty/NonEmpty+Dictionary.swift
+++ b/Sources/NonEmpty/NonEmpty+Dictionary.swift
@@ -52,6 +52,7 @@ extension NonEmpty where Collection: _DictionaryProtocol {
     try self.rawValue.merge(other, uniquingKeysWith: combine)
   }
 
+  @inlinable
   public func merging<S: Sequence>(
     _ other: S,
     uniquingKeysWith combine: (Collection.Value, Collection.Value) throws -> Collection.Value
@@ -70,6 +71,7 @@ extension NonEmpty where Collection: _DictionaryProtocol {
     try self.rawValue.merge(other, uniquingKeysWith: combine)
   }
 
+  @inlinable
   public func merging(
     _ other: [Collection.Key: Collection.Value],
     uniquingKeysWith combine: (Collection.Value, Collection.Value) throws -> Collection.Value

--- a/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
@@ -52,6 +52,7 @@ extension NonEmpty where Collection: RangeReplaceableCollection {
 }
 
 extension NonEmpty {
+  @inlinable
   public func joined<S: Sequence, C: RangeReplaceableCollection>(
     separator: S
   )
@@ -60,6 +61,7 @@ extension NonEmpty {
     NonEmpty<C>(rawValue: C(self.rawValue.joined(separator: separator)))!
   }
 
+  @inlinable
   public func joined<C: RangeReplaceableCollection>() -> NonEmpty<C>
   where Element == NonEmpty<C> {
     return joined(separator: C())

--- a/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
+++ b/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
@@ -12,17 +12,20 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
     self.init(rawValue: Collection(elements))
   }
 
+  @inlinable
   public func contains(_ member: Collection.Element) -> Bool {
     self.rawValue.contains(member)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func union(_ other: NonEmpty) -> NonEmpty {
     var copy = self
     copy.formUnion(other)
     return copy
   }
 
+  @inlinable
   public func union(_ other: Collection) -> NonEmpty {
     var copy = self
     copy.formUnion(other)
@@ -30,19 +33,23 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
   }
 
   @_disfavoredOverload
+  @inlinable
   public func intersection(_ other: NonEmpty) -> Collection {
     self.rawValue.intersection(other.rawValue)
   }
 
+  @inlinable
   public func intersection(_ other: Collection) -> Collection {
     self.rawValue.intersection(other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func symmetricDifference(_ other: NonEmpty) -> Collection {
     self.rawValue.symmetricDifference(other.rawValue)
   }
 
+  @inlinable
   public func symmetricDifference(_ other: Collection) -> Collection {
     self.rawValue.symmetricDifference(other)
   }
@@ -69,99 +76,121 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
   }
 
   @_disfavoredOverload
+  @inlinable
   public func subtracting(_ other: NonEmpty) -> Collection {
     self.rawValue.subtracting(other.rawValue)
   }
 
+  @inlinable
   public func subtracting(_ other: Collection) -> Collection {
     self.rawValue.subtracting(other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func isDisjoint(with other: NonEmpty) -> Bool {
     self.rawValue.isDisjoint(with: other.rawValue)
   }
 
+  @inlinable
   public func isDisjoint(with other: Collection) -> Bool {
     self.rawValue.isDisjoint(with: other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func isSubset(of other: NonEmpty) -> Bool {
     self.rawValue.isSubset(of: other.rawValue)
   }
 
+  @inlinable
   public func isSubset(of other: Collection) -> Bool {
     self.rawValue.isSubset(of: other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func isSuperset(of other: NonEmpty) -> Bool {
     self.rawValue.isSuperset(of: other.rawValue)
   }
 
+  @inlinable
   public func isSuperset(of other: Collection) -> Bool {
     self.rawValue.isSuperset(of: other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func isStrictSubset(of other: NonEmpty) -> Bool {
     self.rawValue.isStrictSubset(of: other.rawValue)
   }
 
+  @inlinable
   public func isStrictSubset(of other: Collection) -> Bool {
     self.rawValue.isStrictSubset(of: other)
   }
 
   @_disfavoredOverload
+  @inlinable
   public func isStrictSuperset(of other: NonEmpty) -> Bool {
     self.rawValue.isStrictSuperset(of: other.rawValue)
   }
 
+  @inlinable
   public func isStrictSuperset(of other: Collection) -> Bool {
     self.rawValue.isStrictSuperset(of: other)
   }
 }
 
 extension SetAlgebra where Self: Collection, Element: Hashable {
+  @inlinable
   public func union(_ other: NonEmpty<Self>) -> NonEmpty<Self> {
     var copy = other
     copy.formUnion(self)
     return copy
   }
 
+  @inlinable
   public func intersection(_ other: NonEmpty<Self>) -> Self {
     self.intersection(other.rawValue)
   }
 
+  @inlinable
   public func symmetricDifference(_ other: NonEmpty<Self>) -> Self {
     self.symmetricDifference(other.rawValue)
   }
 
+  @inlinable
   public mutating func formUnion(_ other: NonEmpty<Self>) {
     self.formUnion(other.rawValue)
   }
 
+  @inlinable
   public func subtracting(_ other: NonEmpty<Self>) -> Self {
     self.subtracting(other.rawValue)
   }
 
+  @inlinable
   public func isDisjoint(with other: NonEmpty<Self>) -> Bool {
     self.isDisjoint(with: other.rawValue)
   }
 
+  @inlinable
   public func isSubset(of other: NonEmpty<Self>) -> Bool {
     self.isSubset(of: other.rawValue)
   }
 
+  @inlinable
   public func isSuperset(of other: NonEmpty<Self>) -> Bool {
     self.isSuperset(of: other.rawValue)
   }
 
+  @inlinable
   public func isStrictSubset(of other: NonEmpty<Self>) -> Bool {
     self.isStrictSubset(of: other.rawValue)
   }
 
+  @inlinable
   public func isStrictSuperset(of other: NonEmpty<Self>) -> Bool {
     self.isStrictSuperset(of: other.rawValue)
   }

--- a/Sources/NonEmpty/NonEmpty+String.swift
+++ b/Sources/NonEmpty/NonEmpty+String.swift
@@ -85,12 +85,14 @@ extension NonEmpty where Collection: StringProtocol {
     self.init(rawValue: Collection(decodingCString: nullTerminatedCodeUnits, as: sourceEncoding))!
   }
 
+  @inlinable
   public func withCString<Result>(_ body: (UnsafePointer<CChar>) throws -> Result) rethrows
     -> Result
   {
     try self.rawValue.withCString(body)
   }
 
+  @inlinable
   public func withCString<Result, Encoding>(
     encodedAs targetEncoding: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
@@ -98,10 +100,12 @@ extension NonEmpty where Collection: StringProtocol {
     try self.rawValue.withCString(encodedAs: targetEncoding, body)
   }
 
+  @inlinable
   public func lowercased() -> NonEmptyString {
     NonEmptyString(self.rawValue.lowercased())!
   }
 
+  @inlinable
   public func uppercased() -> NonEmptyString {
     NonEmptyString(self.rawValue.uppercased())!
   }

--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -20,47 +20,57 @@ public struct NonEmpty<Collection: Swift.Collection>: Swift.Collection {
 
   public subscript(position: Index) -> Element { self.rawValue[position] }
 
+  @inlinable
   public func index(after i: Index) -> Index {
     self.rawValue.index(after: i)
   }
 
   public var first: Element { self.rawValue.first! }
 
+  @inlinable
   public func max(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows -> Element {
     try self.rawValue.max(by: areInIncreasingOrder)!
   }
 
+  @inlinable
   public func min(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows -> Element {
     try self.rawValue.min(by: areInIncreasingOrder)!
   }
 
+  @inlinable
   public func sorted(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows -> NonEmpty<[Element]> {
     NonEmpty<[Element]>(rawValue: try self.rawValue.sorted(by: areInIncreasingOrder))!
   }
 
+  @inlinable
   public func randomElement<T>(using generator: inout T) -> Element where T: RandomNumberGenerator {
     self.rawValue.randomElement(using: &generator)!
   }
 
+  @inlinable
   public func randomElement() -> Element {
     self.rawValue.randomElement()!
   }
 
+  @inlinable
   public func shuffled<T>(using generator: inout T) -> NonEmpty<[Element]>
   where T: RandomNumberGenerator {
     NonEmpty<[Element]>(rawValue: self.rawValue.shuffled(using: &generator))!
   }
 
+  @inlinable
   public func shuffled() -> NonEmpty<[Element]> {
     NonEmpty<[Element]>(rawValue: self.rawValue.shuffled())!
   }
 
+  @inlinable
   public func map<T>(_ transform: (Element) throws -> T) rethrows -> NonEmpty<[T]> {
     NonEmpty<[T]>(rawValue: try self.rawValue.map(transform))!
   }
 
+  @inlinable
   public func flatMap<SegmentOfResult>(
     _ transform: (Element) throws -> NonEmpty<SegmentOfResult>
   ) rethrows -> NonEmpty<[SegmentOfResult.Element]> where SegmentOfResult: Sequence {
@@ -89,6 +99,7 @@ extension NonEmpty: Comparable where Collection: Comparable {
 #endif
 
 extension NonEmpty: Encodable where Collection: Encodable {
+  @inlinable
   public func encode(to encoder: Encoder) throws {
     do {
       var container = encoder.singleValueContainer()
@@ -120,20 +131,24 @@ extension NonEmpty: Decodable where Collection: Decodable {
 extension NonEmpty: RawRepresentable {}
 
 extension NonEmpty where Collection.Element: Comparable {
+  @inlinable
   public func max() -> Element {
     self.rawValue.max()!
   }
 
+  @inlinable
   public func min() -> Element {
     self.rawValue.min()!
   }
 
+  @inlinable
   public func sorted() -> NonEmpty<[Element]> {
     return NonEmpty<[Element]>(rawValue: self.rawValue.sorted())!
   }
 }
 
 extension NonEmpty: BidirectionalCollection where Collection: BidirectionalCollection {
+  @inlinable
   public func index(before i: Index) -> Index {
     self.rawValue.index(before: i)
   }


### PR DESCRIPTION
This MR adds `@inlinable` tag to convenience public functions that do not touch any internal or private variables/methods. The compiler will now be able to inline these methods and call directly the code method content.