### PR TITLE
Replace forced unwrap operator with unsafelyUnwrapped

### DIFF
--- a/Sources/NonEmpty/NonEmpty+Dictionary.swift
+++ b/Sources/NonEmpty/NonEmpty+Dictionary.swift
@@ -22,7 +22,7 @@ extension NonEmpty where Collection: _DictionaryProtocol {
     guard !tail.keys.contains(head.key) else { fatalError("Dictionary contains duplicate key") }
     var tail = tail
     tail[head.key] = head.value
-    self.init(rawValue: tail)!
+    self = .init(rawValue: tail).unsafelyUnwrapped
   }
 
   public init(
@@ -37,7 +37,7 @@ extension NonEmpty where Collection: _DictionaryProtocol {
     } else {
       tail[head.key] = head.value
     }
-    self.init(rawValue: tail)!
+    self = .init(rawValue: tail).unsafelyUnwrapped
   }
 
   public subscript(key: Collection.Key) -> Collection.Value? {
@@ -96,6 +96,6 @@ extension NonEmpty where Collection: _DictionaryProtocol, Collection.Value: Equa
 
 extension NonEmpty where Collection: _DictionaryProtocol & ExpressibleByDictionaryLiteral {
   public init(_ head: Element) {
-    self.init(rawValue: [head.key: head.value])!
+    self = .init(rawValue: [head.key: head.value]).unsafelyUnwrapped
   }
 }

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByArrayLiteral.swift
@@ -5,6 +5,6 @@ extension NonEmpty: ExpressibleByArrayLiteral where Collection: ExpressibleByArr
       Collection.init(arrayLiteral:),
       to: (([Element]) -> Collection).self
     )
-    self.init(rawValue: f(elements))!
+    self = .init(rawValue: f(elements)).unsafelyUnwrapped
   }
 }

--- a/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
+++ b/Sources/NonEmpty/NonEmpty+ExpressibleByDictionaryLiteral.swift
@@ -6,6 +6,6 @@ where Collection: ExpressibleByDictionaryLiteral {
       Collection.init(dictionaryLiteral:),
       to: (([(Collection.Key, Collection.Value)]) -> Collection).self
     )
-    self.init(rawValue: f(elements))!
+    self = .init(rawValue: f(elements)).unsafelyUnwrapped
   }
 }

--- a/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
+++ b/Sources/NonEmpty/NonEmpty+RangeReplaceableCollection.swift
@@ -3,7 +3,7 @@ extension NonEmpty where Collection: RangeReplaceableCollection {
   public init(_ head: Element, _ tail: Element...) {
     var tail = tail
     tail.insert(head, at: tail.startIndex)
-    self.init(rawValue: Collection(tail))!
+    self = .init(rawValue: Collection(tail)).unsafelyUnwrapped
   }
 
   public init?<S>(_ elements: S) where S: Sequence, Collection.Element == S.Element {
@@ -57,7 +57,7 @@ extension NonEmpty {
   )
     -> NonEmpty<C>
   where Element == NonEmpty<C>, S.Element == C.Element {
-    NonEmpty<C>(rawValue: C(self.rawValue.joined(separator: separator)))!
+    NonEmpty<C>(rawValue: C(self.rawValue.joined(separator: separator))).unsafelyUnwrapped
   }
 
   public func joined<C: RangeReplaceableCollection>() -> NonEmpty<C>

--- a/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
+++ b/Sources/NonEmpty/NonEmpty+SetAlgebra.swift
@@ -5,7 +5,7 @@ extension NonEmpty where Collection: SetAlgebra, Collection.Element: Hashable {
   public init(_ head: Collection.Element, _ tail: Collection.Element...) {
     var tail = Collection(tail)
     tail.insert(head)
-    self.init(rawValue: tail)!
+    self = .init(rawValue: tail).unsafelyUnwrapped
   }
 
   public init?<S>(_ elements: S) where S: Sequence, Collection.Element == S.Element {

--- a/Sources/NonEmpty/NonEmpty+String.swift
+++ b/Sources/NonEmpty/NonEmpty+String.swift
@@ -12,7 +12,7 @@ where Collection: ExpressibleByUnicodeScalarLiteral {
   public typealias UnicodeScalarLiteralType = Collection.UnicodeScalarLiteralType
 
   public init(unicodeScalarLiteral value: Collection.UnicodeScalarLiteralType) {
-    self.init(rawValue: Collection(unicodeScalarLiteral: value))!
+    self = .init(rawValue: Collection(unicodeScalarLiteral: value)).unsafelyUnwrapped
   }
 }
 
@@ -22,7 +22,7 @@ where Collection: ExpressibleByExtendedGraphemeClusterLiteral {
     .ExtendedGraphemeClusterLiteralType
 
   public init(extendedGraphemeClusterLiteral value: Collection.ExtendedGraphemeClusterLiteralType) {
-    self.init(rawValue: Collection(extendedGraphemeClusterLiteral: value))!
+    self = .init(rawValue: Collection(extendedGraphemeClusterLiteral: value)).unsafelyUnwrapped
   }
 }
 
@@ -30,7 +30,7 @@ extension NonEmpty: ExpressibleByStringLiteral where Collection: ExpressibleBySt
   public typealias StringLiteralType = Collection.StringLiteralType
 
   public init(stringLiteral value: Collection.StringLiteralType) {
-    self.init(rawValue: Collection(stringLiteral: value))!
+    self = .init(rawValue: Collection(stringLiteral: value)).unsafelyUnwrapped
   }
 }
 
@@ -71,18 +71,18 @@ extension NonEmpty where Collection: StringProtocol {
   public init<C, Encoding>(
     decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C: Swift.Collection, Encoding: _UnicodeEncoding, C.Element == Encoding.CodeUnit {
-    self.init(rawValue: Collection(decoding: codeUnits, as: sourceEncoding))!
+    self = .init(rawValue: Collection(decoding: codeUnits, as: sourceEncoding)).unsafelyUnwrapped
   }
 
   public init(cString nullTerminatedUTF8: UnsafePointer<CChar>) {
-    self.init(rawValue: Collection(cString: nullTerminatedUTF8))!
+    self = .init(rawValue: Collection(cString: nullTerminatedUTF8)).unsafelyUnwrapped
   }
 
   public init<Encoding>(
     decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
     as sourceEncoding: Encoding.Type
   ) where Encoding: _UnicodeEncoding {
-    self.init(rawValue: Collection(decodingCString: nullTerminatedCodeUnits, as: sourceEncoding))!
+    self = .init(rawValue: Collection(decodingCString: nullTerminatedCodeUnits, as: sourceEncoding)).unsafelyUnwrapped
   }
 
   public func withCString<Result>(_ body: (UnsafePointer<CChar>) throws -> Result) rethrows
@@ -99,10 +99,10 @@ extension NonEmpty where Collection: StringProtocol {
   }
 
   public func lowercased() -> NonEmptyString {
-    NonEmptyString(self.rawValue.lowercased())!
+    NonEmptyString(self.rawValue.lowercased()).unsafelyUnwrapped
   }
 
   public func uppercased() -> NonEmptyString {
-    NonEmptyString(self.rawValue.uppercased())!
+    NonEmptyString(self.rawValue.uppercased()).unsafelyUnwrapped
   }
 }

--- a/Sources/NonEmpty/NonEmpty.swift
+++ b/Sources/NonEmpty/NonEmpty.swift
@@ -24,47 +24,47 @@ public struct NonEmpty<Collection: Swift.Collection>: Swift.Collection {
     self.rawValue.index(after: i)
   }
 
-  public var first: Element { self.rawValue.first! }
+  public var first: Element { self.rawValue.first.unsafelyUnwrapped }
 
   public func max(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows -> Element {
-    try self.rawValue.max(by: areInIncreasingOrder)!
+    try self.rawValue.max(by: areInIncreasingOrder).unsafelyUnwrapped
   }
 
   public func min(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows -> Element {
-    try self.rawValue.min(by: areInIncreasingOrder)!
+    try self.rawValue.min(by: areInIncreasingOrder).unsafelyUnwrapped
   }
 
   public func sorted(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows -> NonEmpty<[Element]> {
-    NonEmpty<[Element]>(rawValue: try self.rawValue.sorted(by: areInIncreasingOrder))!
+    NonEmpty<[Element]>(rawValue: try self.rawValue.sorted(by: areInIncreasingOrder)).unsafelyUnwrapped
   }
 
   public func randomElement<T>(using generator: inout T) -> Element where T: RandomNumberGenerator {
-    self.rawValue.randomElement(using: &generator)!
+    self.rawValue.randomElement(using: &generator).unsafelyUnwrapped
   }
 
   public func randomElement() -> Element {
-    self.rawValue.randomElement()!
+    self.rawValue.randomElement().unsafelyUnwrapped
   }
 
   public func shuffled<T>(using generator: inout T) -> NonEmpty<[Element]>
   where T: RandomNumberGenerator {
-    NonEmpty<[Element]>(rawValue: self.rawValue.shuffled(using: &generator))!
+    NonEmpty<[Element]>(rawValue: self.rawValue.shuffled(using: &generator)).unsafelyUnwrapped
   }
 
   public func shuffled() -> NonEmpty<[Element]> {
-    NonEmpty<[Element]>(rawValue: self.rawValue.shuffled())!
+    NonEmpty<[Element]>(rawValue: self.rawValue.shuffled()).unsafelyUnwrapped
   }
 
   public func map<T>(_ transform: (Element) throws -> T) rethrows -> NonEmpty<[T]> {
-    NonEmpty<[T]>(rawValue: try self.rawValue.map(transform))!
+    NonEmpty<[T]>(rawValue: try self.rawValue.map(transform)).unsafelyUnwrapped
   }
 
   public func flatMap<SegmentOfResult>(
     _ transform: (Element) throws -> NonEmpty<SegmentOfResult>
   ) rethrows -> NonEmpty<[SegmentOfResult.Element]> where SegmentOfResult: Sequence {
-    NonEmpty<[SegmentOfResult.Element]>(rawValue: try self.rawValue.flatMap(transform))!
+    NonEmpty<[SegmentOfResult.Element]>(rawValue: try self.rawValue.flatMap(transform)).unsafelyUnwrapped
   }
 }
 
@@ -113,7 +113,7 @@ extension NonEmpty: Decodable where Collection: Decodable {
         .init(codingPath: decoder.codingPath, debugDescription: "Non-empty collection expected")
       )
     }
-    self.init(rawValue: collection)!
+    self = .init(rawValue: collection).unsafelyUnwrapped
   }
 }
 
@@ -121,15 +121,15 @@ extension NonEmpty: RawRepresentable {}
 
 extension NonEmpty where Collection.Element: Comparable {
   public func max() -> Element {
-    self.rawValue.max()!
+    self.rawValue.max().unsafelyUnwrapped
   }
 
   public func min() -> Element {
-    self.rawValue.min()!
+    self.rawValue.min().unsafelyUnwrapped
   }
 
   public func sorted() -> NonEmpty<[Element]> {
-    return NonEmpty<[Element]>(rawValue: self.rawValue.sorted())!
+    return NonEmpty<[Element]>(rawValue: self.rawValue.sorted()).unsafelyUnwrapped
   }
 }
 
@@ -138,7 +138,7 @@ extension NonEmpty: BidirectionalCollection where Collection: BidirectionalColle
     self.rawValue.index(before: i)
   }
 
-  public var last: Element { self.rawValue.last! }
+  public var last: Element { self.rawValue.last.unsafelyUnwrapped }
 }
 
 extension NonEmpty: MutableCollection where Collection: MutableCollection {


### PR DESCRIPTION
https://developer.apple.com/documentation/swift/optional/unsafelyunwrapped

According to the document

> This property trades safety for performance.

But it's safe by design.

So it would be better to use it for performance.

Should we run some tests to compare performance with the forced unwrap operator?