### PR TITLE
Mark updateValue(_:forKey:) as @discardableResult

### DIFF
--- a/Sources/NonEmpty/NonEmpty+Dictionary.swift
+++ b/Sources/NonEmpty/NonEmpty+Dictionary.swift
@@ -12,7 +12,7 @@ public protocol _DictionaryProtocol: Collection where Element == (key: Key, valu
     _ other: [Key: Value], uniquingKeysWith combine: (Value, Value) throws -> Value
   ) rethrows
   @discardableResult mutating func removeValue(forKey key: Key) -> Value?
-  mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
+  @discardableResult mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
 }
 
 extension Dictionary: _DictionaryProtocol {}
@@ -80,6 +80,7 @@ extension NonEmpty where Collection: _DictionaryProtocol {
     return copy
   }
 
+  @discardableResult
   public mutating func updateValue(_ value: Collection.Value, forKey key: Collection.Key)
     -> Collection.Value?
   {


### PR DESCRIPTION
### What

Marks `updateValue(_:forKey:)` on `NonEmpty` where `Collection: _DictionaryProtocol` as `@discardableResult`.

### Why

The method returns the previous value for the given key, matching `Dictionary`'s `updateValue` API.  
However, in many use cases — especially when mutating for side effects — the return value is intentionally unused.

Without `@discardableResult`, Swift emits a compiler warning unless the result is explicitly discarded (e.g. using `_ =`).  
This change removes that friction and aligns behaviour with Swift’s standard library.

### Impact

- No behavioural change
- Fixes unnecessary compiler warnings in calling code
- Improves ergonomics when using `NonEmptyDictionary`